### PR TITLE
Add snippet on how to use named items in the item tree

### DIFF
--- a/invtweaks_docs/index.txt
+++ b/invtweaks_docs/index.txt
@@ -199,12 +199,13 @@ You can also define categories by entering an ore dictionary name. Useful for mo
 
 Items with special extra data
 -------------------------------
-Some items (such as potions), require extra data checks to specify a specific variant::
+Some items (such as potions or named items), require extra data checks to specify a specific variant::
 
    <specialPotion>
      <specialPotionA id="special_potion" data="{Potion:"me:a_special_potion}"/>
      <specialPotionB id="special_potion" data="{Potion:"me:another_special_potion}"/>
    </specialPotion>
+   <specialPickaxe id="diamond_pickaxe" data='{display:{Name:"My Special Pickaxe"}}'/>
 
 
 Adding configured compatibility info

--- a/invtweaks_docs/index.txt
+++ b/invtweaks_docs/index.txt
@@ -202,8 +202,8 @@ Items with special extra data
 Some items (such as potions or named items), require extra data checks to specify a specific variant::
 
    <specialPotion>
-     <specialPotionA id="special_potion" data="{Potion:"me:a_special_potion}"/>
-     <specialPotionB id="special_potion" data="{Potion:"me:another_special_potion}"/>
+     <specialPotionA id="special_potion" data='{Potion:"me:a_special_potion"}'/>
+     <specialPotionB id="special_potion" data='{Potion:"me:another_special_potion"}'/>
    </specialPotion>
    <specialPickaxe id="diamond_pickaxe" data='{display:{Name:"My Special Pickaxe"}}'/>
 


### PR DESCRIPTION
This can be used to add specific items to specific slots, such as pickaxes, but users would need to know some nbt stuff to use this. This pull request makes it more clear for normal users.